### PR TITLE
Add DEFAULT_OPTIONS for specifying load paths

### DIFF
--- a/lib/less.rb
+++ b/lib/less.rb
@@ -9,6 +9,10 @@ module Less
   require 'less/loader'
   require 'less/version'
 
+  DEFAULT_OPTIONS = {
+    :paths => []
+  }
+
   @loader = Less::Loader.new
   @less = @loader.require('less/index')
 

--- a/lib/less/parser.rb
+++ b/lib/less/parser.rb
@@ -48,7 +48,7 @@ module Less
     # @option opts [String] :filename to associate with resulting parse trees (useful for generating errors)
     def initialize(options = {})
       stringy = {}
-      options.each do |k,v|
+      DEFAULT_OPTIONS.merge(options).each do |k,v|
         stringy[k.to_s] = v.is_a?(Array) ? v.map(&:to_s) : v.to_s
       end
       lock do

--- a/spec/less/parser_spec.rb
+++ b/spec/less/parser_spec.rb
@@ -18,10 +18,25 @@ describe Less::Parser do
     expect {subject.parse('{^)')}.should raise_error(Less::ParseError)
   end
 
-  describe "when configured with mulitple load paths" do
+  describe "when configured with multiple load paths" do
     before {@parser = Less::Parser.new :paths => [cwd.join('one'), cwd.join('two')]}
 
     it "will load files from both paths" do
+      @parser.parse('@import "one.less";').to_css.gsub(/\n/,'').strip.should eql ".one {  width: 1;}"
+      @parser.parse('@import "two.less";').to_css.gsub(/\n/,'').strip.should eql ".two {  width: 1;}"
+    end
+  end
+
+  describe "when load paths are specified in as default options" do
+    before do
+      Less::DEFAULT_OPTIONS[:paths].tap do |paths|
+        paths << cwd.join('one')
+        paths << cwd.join('two')
+      end
+      @parser = Less::Parser.new
+    end
+
+    it "will load files from default load paths" do
       @parser.parse('@import "one.less";').to_css.gsub(/\n/,'').strip.should eql ".one {  width: 1;}"
       @parser.parse('@import "two.less";').to_css.gsub(/\n/,'').strip.should eql ".two {  width: 1;}"
     end


### PR DESCRIPTION
Allow load paths to be specified as Less::DEFAULT_OPTIONS[:paths] so that @import can work with Sprockets/Tilt on Rails 3.1.
