### PR TITLE
Line and filename of exception

### DIFF
--- a/lib/less/parser.rb
+++ b/lib/less/parser.rb
@@ -100,13 +100,26 @@ module Less
     # Copies over `error`'s message and backtrace
     # @param [V8::JSError] error native error
     def initialize(error)
-      super(error.message)
-      @backtrace = error.backtrace
+      @line = error.value.line if error.value.respond_to? :line
+      @filename = error.value.filename if error.value.respond_to? :filename
+      @message = error.message
+      
+      super(self.full_message)
+      
+      @backtrace = error.backtrace      
     end
 
     # @return [Array] the backtrace frames
     def backtrace
       @backtrace
+    end
+
+    def full_message
+      if @line && @filename
+        "Error at #{@filename}:#{@line} - #{@message}"
+      else
+        @message
+      end
     end
   end
 end


### PR DESCRIPTION
Adds less filename and line number to exceptions.  Makes debugging a large project much easier.  FYI, The specs still pass, but I've only tested this with a single exception.
