### PR TITLE
OptionParser::NeedlessArgument error with bin/lessc --include-path

### DIFF
--- a/bin/lessc
+++ b/bin/lessc
@@ -17,6 +17,8 @@ output = nil
 require 'optparse'
 
 opts = OptionParser.new do |opts|
+  opts.summary_width = 37
+
   opts.banner = 'Usage: lessc [options] [INPUT]'
   
   opts.on('-h', '--help', 'print this help') do
@@ -52,7 +54,7 @@ opts = OptionParser.new do |opts|
   require 'rbconfig'
   is_windows = (RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/)
   separator = is_windows ? ';' : ':'
-  opts.on('--paths', '--include-path', 
+  opts.on('--paths PATHS', '--include-path PATHS',
     "paths to include separated by '#{separator}'") do |paths|
     paths = paths.split(separator).map do |path|
       path.empty? ? nil : File.expand_path(path)


### PR DESCRIPTION
I'm getting an OptionParser::NeedlessArgument exception when using --include-path with the lessc binary. I think --paths/--include-path needs a required argument.
