### PR TITLE
Include dependency on therubyracer

### DIFF
--- a/less.gemspec
+++ b/less.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency "commonjs", "~> 0.2.6"
+  s.add_dependency "therubyracer", "~> 0.10"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", "~> 2.0"
 


### PR DESCRIPTION
After installing the Less gem for use with Rails, you get "[WARNING] Please install gem 'therubyracer' to use Less." 

This commit simply adds the dependency to the gemspec so it can be installed when you install Less.
