### PR TITLE
Give instructions to pull down less.js submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Once you have a parser instantiated, you can parse code to get your AST !
     tree.to_css #=> .class {\n  width: 2;\n}\n
     tree.to_css(:compress => true) #=> .class{width:2;}
 
+tests
+-----
+
+This repository contains less.js as a submodule, so to run the tests, you'll need to grab that code as well. To do that, run `git submodule update --init` from the root directory of the project.
+
+
 license
 -------
 


### PR DESCRIPTION
I was confused at first on why the tests would not run when I originally ran them. It took tracing through the source code to find out why, so I figured this little note might save someone else the trouble.
