### PR TITLE
Fix 'missing closing `}`' error on therubyracer 0.11.x.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,5 @@ source :rubygems
 
 gemspec
 
-
-gem "therubyracer", "~> 0.10.0", :require => nil, :platforms => :ruby
+gem "therubyracer", "~> 0.11.0", :require => nil, :platforms => :ruby
 gem "therubyrhino", "~> 1.73.3", :require => nil, :platforms => :jruby

--- a/lib/less/java_script/v8_context.rb
+++ b/lib/less/java_script/v8_context.rb
@@ -77,8 +77,8 @@ module Less
           #   }, env);
           # 
           # comes back as value: RuntimeError !
-          elsif e.value.to_s == "missing closing `}`"
-            raise Less::ParseError.new(e.value.to_s)
+          elsif e.message == "missing closing `}`"
+            raise Less::ParseError.new(e)
           end
           raise Less::Error.new(e)
         end


### PR DESCRIPTION
Fix also works on 0.10.x. The newer version was prepending "Error:" to
the string which was breaking the check.
