### PR TITLE
Escape } in context regexes for ruby 1.8.7.

### DIFF
--- a/lib/less/java_script/rhino_context.rb
+++ b/lib/less/java_script/rhino_context.rb
@@ -73,7 +73,7 @@ module Less
           if e.value && ( e.value['message'] || e.value['type'].is_a?(String) )
             raise Less::ParseError.new(e, e.value) # LessError
           end
-          if e.unwrap.to_s =~ /missing closing `}`/
+          if e.unwrap.to_s =~ /missing closing `\}`/
             raise Less::ParseError.new(e.unwrap.to_s)
           end
           if e.message && e.message[0, 12] == "Syntax Error"

--- a/lib/less/java_script/v8_context.rb
+++ b/lib/less/java_script/v8_context.rb
@@ -77,7 +77,7 @@ module Less
           #   }, env);
           #
           # comes back as value: RuntimeError !
-          elsif e.value.to_s =~ /missing closing `}`/
+          elsif e.value.to_s =~ /missing closing `\}`/
             raise Less::ParseError.new(e.value.to_s)
           end
           raise Less::Error.new(e)


### PR DESCRIPTION
Ruby 1.8.7 throws:
warning: regexp has `}' without escape

I'm not sure if it's worth fixing this or not, but we're stuck with 1.8.7 on a few servers for hopefully not too much longer.
