### PR TITLE
Add ability to provide default JavaScript load paths

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'commonjs', git: 'git://github.com/bandzoogle/commonjs.rb.git'
+
 gem "therubyracer", "~> 0.12.0", :require => nil, :platforms => :ruby
 gem "therubyrhino", ">= 2.0.2",  :require => nil, :platforms => :jruby
 

--- a/less.gemspec
+++ b/less.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency "commonjs", "~> 0.2.7"
+  s.add_dependency "commonjs", "~> 0.2.8"
 end

--- a/lib/less.rb
+++ b/lib/less.rb
@@ -8,8 +8,8 @@ require 'less/java_script'
 
 module Less
   extend Less::Defaults
-  
-  # NOTE: keep the @loader as less-rails depends on 
+
+  # NOTE: keep the @loader as less-rails depends on
   # it as it overrides some less/tree.js functions!
   @loader = Less::Loader.new
   @less = @loader.require('less/index')
@@ -17,7 +17,7 @@ module Less
   def self.[](name)
     @less[name]
   end
-  
+
   # exposes less.Parser
   def self.Parser
     self['Parser']
@@ -28,5 +28,9 @@ module Less
   def self.tree
     self['tree']
   end
-  
+
+  def self.add_javascript_path(path)
+    @loader.add_javascript_path(path)
+  end
+
 end

--- a/lib/less/defaults.rb
+++ b/lib/less/defaults.rb
@@ -2,11 +2,15 @@ module Less
   module Defaults
 
     def defaults
-      @defaults ||= { :paths => [], :relativeUrls => true, :syncImport => true }
+      @defaults ||= { :paths => [], :relativeUrls => true, :syncImport => true, :javascript_paths => [] }
     end
 
     def paths
       defaults[:paths]
+    end
+
+    def javascript_paths
+    	defaults[:javascript_paths]
     end
 
   end

--- a/lib/less/loader.rb
+++ b/lib/less/loader.rb
@@ -16,7 +16,7 @@ module Less
       @context['console'] = Console.new
       @context['Buffer'] = Buffer
       path = Pathname(__FILE__).dirname.join('js', 'lib')
-      @environment = CommonJS::Environment.new(@context, :path => path.to_s)
+      @environment = CommonJS::Environment.new(@context, :path => Less.javascript_paths + [path.to_s])
       @environment.native('path', Path)
       @environment.native('util', Util)
       @environment.native('fs', FS)

--- a/lib/less/loader.rb
+++ b/lib/less/loader.rb
@@ -28,6 +28,10 @@ module Less
       @environment.require(module_id)
     end
 
+    def add_javascript_path(path)
+      @environment.add_path(path)
+    end
+
     # JS exports (required by less.js) :
 
     class Process # :nodoc:

--- a/lib/less/version.rb
+++ b/lib/less/version.rb
@@ -1,3 +1,3 @@
 module Less
-  VERSION = '2.7.0'
+  VERSION = '2.7.1'
 end

--- a/lib/less/version.rb
+++ b/lib/less/version.rb
@@ -1,3 +1,3 @@
 module Less
-  VERSION = '2.7.1'
+  VERSION = '2.8.0'
 end

--- a/lib/less/version.rb
+++ b/lib/less/version.rb
@@ -1,3 +1,3 @@
 module Less
-  VERSION = '2.6.0'
+  VERSION = '2.7.0'
 end

--- a/lib/less/version.rb
+++ b/lib/less/version.rb
@@ -1,3 +1,3 @@
 module Less
-  VERSION = '2.8.0'
+  VERSION = '2.7.1'
 end

--- a/spec/less/js/test.js
+++ b/spec/less/js/test.js
@@ -1,0 +1,3 @@
+var test = function() {
+	console.log('hello');
+};

--- a/spec/less/loader_spec.rb
+++ b/spec/less/loader_spec.rb
@@ -58,4 +58,18 @@ describe Less::Loader do
     after { Less.javascript_paths.delete path }
   end
 
+  describe '.add_javascript_path' do
+    let(:path) { Pathname(__FILE__).dirname.join('js') }
+
+    before { subject.add_javascript_path(path) }
+
+    it 'should be able to include javascript from that path' do
+      lambda { subject.environment.require 'test.js' }.should_not raise_error
+    end
+
+    it 'should be able to include javascript from lib path' do
+      lambda { subject.environment.require 'less/index' }.should_not raise_error
+    end
+  end
+
 end

--- a/spec/less/loader_spec.rb
+++ b/spec/less/loader_spec.rb
@@ -42,4 +42,20 @@ describe Less::Loader do
 
   end
 
+  describe 'when javascript_paths are included in default options' do
+    let(:path) { Pathname(__FILE__).dirname.join('js') }
+
+    before { Less.javascript_paths << path }
+
+    it 'should be able to include javascript from that path' do
+      lambda { subject.environment.require 'test.js' }.should_not raise_error
+    end
+
+    it 'should be able to include javascript from lib path' do
+      lambda { subject.environment.require 'less/index' }.should_not raise_error
+    end
+
+    after { Less.javascript_paths.delete path }
+  end
+
 end


### PR DESCRIPTION
This allows us to add our own load paths and thus load external JavaScript files such as custom less functions. For example we could do the following, note for this to work the gem must not be required by the Gemfile due to auto initialisation of the loader.

``` ruby
  module Less
    module Defaults
      def self.extended(base)
        base.javascript_paths << ::Rails.root.join('lib', 'assets', 'javascripts')
      end
    end

    module Customisations
      def self.included(base)
        loader = base.instance_variable_get :@loader
        loader.require('less/custom-less-functions')
      end
    end
  end

  require 'less'

  module Less
    include Less::Customisations
  end 
```
